### PR TITLE
Address OPENSSL deprecation warning

### DIFF
--- a/lib/bcdatabase.rb
+++ b/lib/bcdatabase.rb
@@ -35,7 +35,7 @@ module Bcdatabase
     # based on http://snippets.dzone.com/posts/show/576
     def encipher(direction, s)
       # the order of operations here is very important
-      c = OpenSSL::Cipher::Cipher.new(CIPHER)
+      c = OpenSSL::Cipher.new(CIPHER)
       c.send direction
       c.key = pass
       t = c.update(s)


### PR DESCRIPTION
OPENSSL::Cipher::Cipher is deprecated. 
The documentation and examples of where this issue has been resolved states to use OPENSSL::Cipher
https://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL/Cipher/Cipher.html